### PR TITLE
Updated xTranscriptTermType/academicSummary

### DIFF
--- a/Report/SIFNAxSRECommonTypes.xsd
+++ b/Report/SIFNAxSRECommonTypes.xsd
@@ -157,7 +157,7 @@
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="academicSummary" type="xAcademicSummaryType" minOccurs="0"/>
+			<xs:element name="academicSummary" type="xSreAcademicSummaryType" minOccurs="0"/>
 			<xs:any namespace="##other" processContents="strict" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>


### PR DESCRIPTION
I updated xTranscriptTermType/academicSummary to use xSreAcademicSummary
instead of xAcademicSummary.  We need this for full SRE functionality
and translatability from 3.2 SRE spec.

Closes #45
