### PR TITLE
added pdf elements, issue #155

### DIFF
--- a/Entity/SIFNAindividualizedEducationPlan/administrativeData/iepAdministrativeDataType.xsd
+++ b/Entity/SIFNAindividualizedEducationPlan/administrativeData/iepAdministrativeDataType.xsd
@@ -38,6 +38,17 @@
 							<xs:documentation>This is the reference identifier of the student who is the subject of the IEP.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element name="schoolRefId" type="iepCommonSchoolRefIdPointerType" minOccurs="0">
+						<xs:annotation>
+							<xs:appinfo>
+								<elementName>School Reference Identifier</elementName>
+								<sifChar>O</sifChar>
+								<cedsId/>
+								<cedsURL></cedsURL>
+							</xs:appinfo>
+							<xs:documentation>This is the reference identifier of the school that administers the IEP (especially for cases where the student is attending a different school).</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 					<xs:element type="xs:date" name="reevaluationDueDate" minOccurs="0">
 						<xs:annotation>
 							<xs:appinfo>

--- a/Entity/SIFNAindividualizedEducationPlan/administrativeData/iepAdministrativeDataType.xsd
+++ b/Entity/SIFNAindividualizedEducationPlan/administrativeData/iepAdministrativeDataType.xsd
@@ -35,7 +35,7 @@
 								<cedsId/>
 								<cedsURL></cedsURL>
 							</xs:appinfo>
-							<xs:documentation>This is the reference identifier of the student, for when the student record is expected to be retrievable. This is an alternative to the student though both may be present.</xs:documentation>
+							<xs:documentation>This is the reference identifier of the student who is the subject of the IEP.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element type="xs:date" name="reevaluationDueDate" minOccurs="0">

--- a/Entity/SIFNAindividualizedEducationPlan/administrativeData/iepAdministrativeDataType.xsd
+++ b/Entity/SIFNAindividualizedEducationPlan/administrativeData/iepAdministrativeDataType.xsd
@@ -49,6 +49,17 @@
 							<xs:documentation>This is the reference identifier of the school that administers the IEP (especially for cases where the student is attending a different school).</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element name="planPdfRefId" type="iepCommonPdfRefIdPointerType" minOccurs="0">
+						<xs:annotation>
+							<xs:appinfo>
+								<elementName>Plan PDF Identifier</elementName>
+								<sifChar>O</sifChar>
+								<cedsId/>
+								<cedsURL></cedsURL>
+							</xs:appinfo>
+							<xs:documentation>This is the reference identifier of the PDF corresponding to this plan.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 					<xs:element type="xs:date" name="reevaluationDueDate" minOccurs="0">
 						<xs:annotation>
 							<xs:appinfo>

--- a/Entity/SIFNAindividualizedEducationPlan/administrativeData/iepTransmitPermissionListType.xsd
+++ b/Entity/SIFNAindividualizedEducationPlan/administrativeData/iepTransmitPermissionListType.xsd
@@ -70,6 +70,18 @@
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="school" type="iepCommonSchoolRefIdPointerType" minOccurs="0">
+				<xs:annotation>
+					<xs:appinfo>
+						<elementName> School </elementName>
+						<sifChar>O</sifChar>
+						<cedsId/>
+						<cedsURL/>
+					</xs:appinfo>
+					<xs:documentation> Pointer to school or building that needs access to IEP
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="serviceProvider" type="iepCommonServiceProviderType" minOccurs="0">
 				<xs:annotation>
 					<xs:appinfo>

--- a/Entity/SIFNAindividualizedEducationPlan/iepCommonTypes.xsd
+++ b/Entity/SIFNAindividualizedEducationPlan/iepCommonTypes.xsd
@@ -53,6 +53,12 @@
 		</xs:annotation>
 		<xs:restriction base="gUUIDType"/>
 	</xs:simpleType>
+	<xs:simpleType name="iepCommonPdfRefIdPointerType">
+		<xs:annotation>
+			<xs:documentation>A refId that refers to a gPdfFileType. The RefId points to the object instance. </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="gUUIDType"/>
+	</xs:simpleType>
 	
 	<xs:complexType name="iepCommonExternalPartyType">
 		<xs:annotation>

--- a/Entity/SIFNAindividualizedEducationPlan/iepCommonTypes.xsd
+++ b/Entity/SIFNAindividualizedEducationPlan/iepCommonTypes.xsd
@@ -41,6 +41,12 @@
 		</xs:annotation>
 		<xs:restriction base="gUUIDType"/>
 	</xs:simpleType>
+	<xs:simpleType name="iepCommonSchoolRefIdPointerType">
+		<xs:annotation>
+			<xs:documentation>A refId that refers to an instance of xSchoolType object. The RefId points to the object instance. </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="gUUIDType"/>
+	</xs:simpleType>
 	<xs:simpleType name="iepCommonOrganizationRefIdPointerType">
 		<xs:annotation>
 			<xs:documentation>A refId that refers to an instance of xOrganization object. The RefId points to the object instance. </xs:documentation>

--- a/Report/SIFNAtransferIep/tiepHistory/tiepHistoryListItemType.xsd
+++ b/Report/SIFNAtransferIep/tiepHistory/tiepHistoryListItemType.xsd
@@ -55,7 +55,22 @@
 						<cedsURL/>
 					</xs:appinfo>
 					<xs:documentation>
-						Pointer to school or other LEA where this historical IEP was created
+						Pointer to LEA where this historical IEP was created
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="school" type="iepCommonSchoolRefIdPointerType" minOccurs="0">
+				<xs:annotation>
+					<xs:appinfo>
+						<elementName>
+							School Reference
+						</elementName>
+						<sifChar>O</sifChar>
+						<cedsId/>
+						<cedsURL/>
+					</xs:appinfo>
+					<xs:documentation>
+						Pointer to school or building where this historical IEP was created
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>

--- a/Report/SIFNAtransferIep/tiepReferenceObjects/tiepReferenceObjects.xsd
+++ b/Report/SIFNAtransferIep/tiepReferenceObjects/tiepReferenceObjects.xsd
@@ -35,7 +35,42 @@
 								<cedsURL/>
 							</xs:appinfo>
 							<xs:documentation>
-								Information for a school or other Local Education Agency referenced in the IEP by iepCommonLeaRefIdPointerType
+								Information for a Local Education Agency referenced in the IEP by iepCommonLeaRefIdPointerType
+							</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="tiepReferenceObjectSchoolList">
+		<xs:annotation>
+			<xs:appinfo>
+				<elementName>School Reference List</elementName>
+				<events>no</events>
+				<isSIFObject>yes</isSIFObject>
+				<cedsId/>
+				<cedsURL/>
+			</xs:appinfo>
+			<xs:documentation>
+				List of schools or buildings referenced in the IEP
+			</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="gSIF_BaseType">
+				<xs:sequence>
+					<xs:element type='xSchoolType' name="referenceSchool" minOccurs="0" maxOccurs="unbounded">
+						<xs:annotation>
+							<xs:appinfo>
+								<elementName>
+									School Info
+								</elementName>
+								<sifChar>O</sifChar>
+								<cedsId/>
+								<cedsURL/>
+							</xs:appinfo>
+							<xs:documentation>
+								Information for a school or building referenced in the IEP by iepCommonLeaRefIdPointerType
 							</xs:documentation>
 						</xs:annotation>
 					</xs:element>
@@ -187,7 +222,7 @@
 								<cedsId/>
 								<cedsURL/>
 							</xs:appinfo>
-							<xs:documentation>List of school or other Local Education Agencies referenced in this IEP</xs:documentation>
+							<xs:documentation>List of Local Education Agencies referenced in this IEP</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element type="tiepReferenceObjectContactList" name="contactList" minOccurs="0">

--- a/Report/SIFNAtransferIep/tiepReferenceObjects/tiepReferenceObjects.xsd
+++ b/Report/SIFNAtransferIep/tiepReferenceObjects/tiepReferenceObjects.xsd
@@ -183,6 +183,41 @@
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
+	<xs:complexType name="tiepReferenceObjectPdfFileListType">
+		<xs:annotation>
+			<xs:appinfo>
+				<elementName>PDF File Reference List</elementName>
+				<events>no</events>
+				<isSIFObject>yes</isSIFObject>
+				<cedsId/>
+				<cedsURL/>
+			</xs:appinfo>
+			<xs:documentation>
+				List of PDFs referenced in the IEP
+			</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="gSIF_BaseType">
+				<xs:sequence>
+					<xs:element type='gPdfFileType' name="pdf" minOccurs="0" maxOccurs="unbounded">
+						<xs:annotation>
+							<xs:appinfo>
+								<elementName>
+									PDF File
+								</elementName>
+								<sifChar>O</sifChar>
+								<cedsId/>
+								<cedsURL/>
+							</xs:appinfo>
+							<xs:documentation>
+								PDF File
+							</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
 	<xs:complexType name="tiepReferenceObjectsType">
 		<xs:annotation>
 			<xs:appinfo>
@@ -249,6 +284,19 @@
 								<cedsURL/>
 							</xs:appinfo>
 							<xs:documentation>List of xStaff objects for staff members who participate in this IEP</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element type="tiepReferenceObjectPdfFileListType" name="pdfList" minOccurs="0">
+						<xs:annotation>
+							<xs:appinfo>
+								<elementName>
+									PDF File Reference List
+								</elementName>
+								<sifChar>O</sifChar>
+								<cedsId/>
+								<cedsURL/>
+							</xs:appinfo>
+							<xs:documentation>List of gPdfFileType objects for PDFs that participate in this IEP</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element type="tiepReferenceObjectOrganizationListType" name="organizationList" minOccurs="0">

--- a/SIFglobalBaseTypes.xsd
+++ b/SIFglobalBaseTypes.xsd
@@ -89,7 +89,7 @@
 			<xs:element name="hexValue" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>As of version 3.4 hex values are not published with the code sets.</xs:documentation>
-				</xs:annotation>				
+				</xs:annotation>
 				<xs:simpleType>
 					<xs:restriction base="xs:hexBinary">
 						<xs:length value="4"/>
@@ -219,7 +219,7 @@
 			<xs:element name="hexValue" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>As of version 3.4 hex values are not published with the code sets.</xs:documentation>
-				</xs:annotation>				
+				</xs:annotation>
 				<xs:simpleType>
 					<xs:restriction base="xs:hexBinary">
 						<xs:length value="4"/>
@@ -349,4 +349,40 @@
 			<xs:enumeration value="Yes"/>
 		</xs:restriction>
 	</xs:simpleType>
+
+	<xs:simpleType name="gBaseFileDataType">
+		<xs:annotation>
+			<xs:documentation>Encoded contents of a file</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:base64Binary"/>
+	</xs:simpleType>
+
+	<xs:complexType name="gPdfFileType">
+		<xs:annotation>
+			<xs:documentation>PDF Document.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="fileData" type='gBaseFileDataType' />
+			<xs:element name="mimeType" type='xs:string'>
+				<xs:annotation>
+					<xs:documentation>MIME type</xs:documentation>
+					<xs:appinfo>
+						<sifChar>M</sifChar>
+						<referenceURL>
+							https://www.iana.org/assignments/media-types/media-types.xhtml
+						</referenceURL>
+					</xs:appinfo>
+				</xs:annotation>
+				<xs:restriction>
+					<xs:enumeration value="application/pdf"/>
+				</xs:restriction>
+			</xs:element>
+			<xs:element name="fileName" type='xs:string'>
+				<xs:annotation>
+					<xs:documentation>Name of the file</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
 </xs:schema>


### PR DESCRIPTION
xIndividualizedEducationPlan and xIepTransfer did not have the ability to specify the PDF document that was signed by the parents. Global elements were added for PDF and are referenced in the IEP objects.